### PR TITLE
fix: 增加 Gunicorn 请求行大小限制以支持长题目

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN mkdir -p logs
 EXPOSE 5000
 
 # 默认命令
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--limit-request-line", "16380", "app:app"]


### PR DESCRIPTION
将 limit-request-line 从默认的 4094 提高到 16380 字节，
解决题目或选项内容较长时的 "Request Line is too large" 错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server configuration to support longer HTTP request lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->